### PR TITLE
Action API Uptake for Publish CheckOut

### DIFF
--- a/src/app/admin/pages/pageform/PageForm.jsx
+++ b/src/app/admin/pages/pageform/PageForm.jsx
@@ -99,6 +99,7 @@ export default class PageForm extends Component {
       <div className={styles.wrapper}>
         <MenuBar
           pages={this.state.pages}
+          pageId={this.state.pageId}
           save={this.save.bind(this)}
           new={this.new.bind(this)}
           delete={this.delete.bind(this)}

--- a/src/app/admin/pages/pageform/PageForm.jsx
+++ b/src/app/admin/pages/pageform/PageForm.jsx
@@ -5,7 +5,10 @@ import Header from './header/Header.jsx'
 import Blocks from './blocks/Blocks.jsx'
 import Preview from './preview/Preview.jsx'
 
-import { fetchPages, fetchPage, insertPage, savePage, deletePage } from './PageFormOperations.js';
+import {
+  fetchPages, fetchPage,
+  insertPage, savePage, deletePage,
+  executeAction } from './PageFormOperations.js';
 
 import styles from './pageForm.mod.scss'
 
@@ -94,6 +97,40 @@ export default class PageForm extends Component {
     })
   }
 
+  checkIn() {
+    const action = {
+      action: 'check_in',
+      id: this.state.pageId
+    }
+
+    executeAction(action, (id) => {
+      this.fetchAll();
+    })
+  }
+
+  checkOut() {
+    const action = {
+      action: 'check_out',
+      id: this.state.pageId
+    }
+
+    executeAction(action, (id) => {
+      this.fetchAll();
+    })
+  }
+
+  publish() {
+    const action = {
+      action: 'publish',
+      id: this.state.pageId,
+      slug: this.state.slug
+    }
+
+    executeAction(action, (id) => {
+      this.fetchAll();
+    })
+  }
+
   render() {
     return(
       <div className={styles.wrapper}>
@@ -101,6 +138,9 @@ export default class PageForm extends Component {
           pages={this.state.pages}
           pageId={this.state.pageId}
           save={this.save.bind(this)}
+          publish={this.publish.bind(this)}
+          checkOut={this.checkOut.bind(this)}
+          checkIn={this.checkIn.bind(this)}
           new={this.new.bind(this)}
           delete={this.delete.bind(this)}
           focus={this.focus.bind(this)} />

--- a/src/app/admin/pages/pageform/PageForm.jsx
+++ b/src/app/admin/pages/pageform/PageForm.jsx
@@ -26,7 +26,8 @@ export default class PageForm extends Component {
       caption: page.caption,
       blocks: page.blocks,
       sequence: page.sequence,
-      slug: page.slug
+      slug: page.slug,
+      mode: page.mode
     })
   }
 
@@ -37,7 +38,8 @@ export default class PageForm extends Component {
       caption: this.state.caption,
       blocks: JSON.stringify(this.state.blocks),
       sequence: this.state.sequence,
-      slug: this.state.slug
+      slug: this.state.slug,
+      mode: this.state.mode
     }
   }
 
@@ -131,14 +133,27 @@ export default class PageForm extends Component {
     })
   }
 
+  unpublish() {
+    const action = {
+      action: 'unpublish',
+      id: this.state.pageId,
+    }
+
+    executeAction(action, (id) => {
+      this.fetchAll();
+    })
+  }
+
   render() {
     return(
       <div className={styles.wrapper}>
         <MenuBar
           pages={this.state.pages}
           pageId={this.state.pageId}
+          mode={this.state.mode}
           save={this.save.bind(this)}
           publish={this.publish.bind(this)}
+          unpublish={this.unpublish.bind(this)}
           checkOut={this.checkOut.bind(this)}
           checkIn={this.checkIn.bind(this)}
           new={this.new.bind(this)}

--- a/src/app/admin/pages/pageform/PageFormOperations.js
+++ b/src/app/admin/pages/pageform/PageFormOperations.js
@@ -8,7 +8,7 @@ import { API_V1 } from 'http/url.js';
 
 export const fetchPages = function(callback) {
 
-  GET(API_V1 + 'pages?fields=id,header,sequence&sort=sequence', (payload) => {
+  GET(API_V1 + 'pages?fields=id,header,sequence, mode&sort=sequence', (payload) => {
     if (payload.hasErrors()) {
       Logger.error("Fetch failed for all Pages. Cause: " + payload.getErrors())
     } else {
@@ -84,3 +84,21 @@ export const deletePage = function(id, callback) {
     }
   })
 }
+
+export const executeAction = function(body, callback) {
+  if (!body) {
+    return;
+  }
+
+  POST(API_V1 + 'action', body, (payload) => {
+    if (payload.hasErrors()) {
+      Logger.error("Action failed. Cause: " + JSON.stringify(payload));
+    } else {
+      const id = payload.getFirst().id
+      Logger.info("Action Executed. " + id);
+
+      callback(id)
+    }
+  })
+}
+

--- a/src/app/admin/pages/pageform/menubar/MenuBar.jsx
+++ b/src/app/admin/pages/pageform/menubar/MenuBar.jsx
@@ -12,17 +12,17 @@ export default function MenuBar(props) {
         pages={props.pages}
         focus={props.focus} />
 
-      <ActionBtn text="Save"
+      {props.pageId && <ActionBtn text="Save"
         classNames={styles.button}
-        onClick={props.save} />
+        onClick={props.save} />}
 
-      <ActionBtn text="Delete"
+      {props.pageId && <ActionBtn text="Check Out"
+        classNames={styles.button}
+        onClick={{}} />}
+
+      {props.pageId && <ActionBtn text="Delete"
           classNames={styles.button}
-          onClick={props.delete} />
-
-      <ActionBtn text="Check Out"
-        classNames={styles.button}
-        onClick={{}} />
+          onClick={props.delete} />}
 
       <ActionBtn text="New"
         classNames={styles.button}

--- a/src/app/admin/pages/pageform/menubar/MenuBar.jsx
+++ b/src/app/admin/pages/pageform/menubar/MenuBar.jsx
@@ -12,23 +12,33 @@ export default function MenuBar(props) {
         pages={props.pages}
         focus={props.focus} />
 
-      {props.pageId && <ActionBtn text="Save"
-        classNames={styles.button}
-        onClick={props.save} />}
+      {props.pageId && props.mode && props.mode != 'published' &&
+        <ActionBtn text="Save"
+          classNames={styles.button}
+          onClick={props.save} />}
 
-      {props.pageId && <ActionBtn text="Publish"
-        classNames={styles.button}
-        onClick={props.publish} />}
+      {props.pageId && props.mode && props.mode != 'published' && props.mode != 'checked_out' &&
+        <ActionBtn text="Publish"
+          classNames={styles.button}
+          onClick={props.publish} />}
 
-      {props.pageId && <ActionBtn text="Check Out"
-        classNames={styles.button}
-        onClick={props.checkOut} />}
+      {props.pageId && props.mode && props.mode == 'published' &&
+        <ActionBtn text="Unpublish"
+          classNames={styles.button}
+          onClick={props.unpublish} />}
 
-      {props.pageId && <ActionBtn text="Check In"
-        classNames={styles.button}
-        onClick={props.checkIn} />}
+      {props.pageId && props.mode && props.mode == 'published' &&
+        <ActionBtn text="Check Out"
+          classNames={styles.button}
+          onClick={props.checkOut} />}
 
-      {props.pageId && <ActionBtn text="Delete"
+      {props.pageId && props.mode && props.mode == 'checked_out' &&
+        <ActionBtn text="Check In"
+          classNames={styles.button}
+          onClick={props.checkIn} />}
+
+      {props.pageId && props.mode && props.mode != 'published' &&
+        <ActionBtn text="Delete"
           classNames={styles.button}
           onClick={props.delete} />}
 

--- a/src/app/admin/pages/pageform/menubar/MenuBar.jsx
+++ b/src/app/admin/pages/pageform/menubar/MenuBar.jsx
@@ -16,9 +16,17 @@ export default function MenuBar(props) {
         classNames={styles.button}
         onClick={props.save} />}
 
+      {props.pageId && <ActionBtn text="Publish"
+        classNames={styles.button}
+        onClick={props.publish} />}
+
       {props.pageId && <ActionBtn text="Check Out"
         classNames={styles.button}
-        onClick={{}} />}
+        onClick={props.checkOut} />}
+
+      {props.pageId && <ActionBtn text="Check In"
+        classNames={styles.button}
+        onClick={props.checkIn} />}
 
       {props.pageId && <ActionBtn text="Delete"
           classNames={styles.button}

--- a/src/app/admin/pages/pageform/menubar/pagelist/PageList.jsx
+++ b/src/app/admin/pages/pageform/menubar/pagelist/PageList.jsx
@@ -14,6 +14,7 @@ export default function PageList(props) {
             pageId={page.id}
             header={page.header}
             sequence={page.sequence}
+            mode={page.mode}
             focus={props.focus}/>
         })}
       </div>

--- a/src/app/admin/pages/pageform/menubar/pagelist/element/Element.jsx
+++ b/src/app/admin/pages/pageform/menubar/pagelist/element/Element.jsx
@@ -10,8 +10,13 @@ export default function Element(props) {
 
   return(
     <div className={styles.wrapper} onClick={focus}>
+
       <div className={styles.header}>
         { props.header }
+      </div>
+
+      <div className={[styles.mode, styles[props.mode]].join(" ")}>
+        { props.mode }
       </div>
 
       <div className={styles.sequence}>

--- a/src/app/admin/pages/pageform/menubar/pagelist/element/element.mod.scss
+++ b/src/app/admin/pages/pageform/menubar/pagelist/element/element.mod.scss
@@ -20,6 +20,22 @@
     overflow: hidden;
   }
 
+  .mode {
+    @include flex($dir: row)
+    @include center($horz: flex-start);
+
+    font-size: 12px;
+    height: 100%;
+    width: 200px;
+
+    overflow: hidden;
+
+    text-align: center;
+
+    padding-left: 10px;
+    @include borderLeft($color: $brand);
+  }
+
   .sequence {
     height: 100%;
     width: 30px;
@@ -28,8 +44,16 @@
     text-align: center;
 
     padding-left: 10px;
-    @include borderLeft;
+    @include borderLeft($color: $brand);
   }
+}
+
+.published {
+  background-color: rgba(mix-brand($color: red, $weight: 50%), 0.15)
+}
+
+.checked_out {
+  background-color: rgba(mix-brand($color: green, $weight: 50%), 0.15)
 }
 
 .wrapper:hover {

--- a/src/app/admin/pages/pageform/menubar/pagelist/pageList.mod.scss
+++ b/src/app/admin/pages/pageform/menubar/pagelist/pageList.mod.scss
@@ -43,6 +43,8 @@
     height: 0;
     width: 0;
 
+    padding: 10px;
+
     opacity: 0;
     transition: opacity 500ms linear, width 500ms cubic-bezier(0.8, 0, 0.02, 0.9);
 

--- a/src/app/main/pages/Pages.jsx
+++ b/src/app/main/pages/Pages.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
 
 import List from './list/List.jsx'
@@ -6,21 +6,15 @@ import Page from './page/Page.jsx'
 
 import styles from './pages.mod.scss'
 
-export default class Pages extends Component {
+export default function Pages(props) {
 
-  render(){
-
-    return(
-        <div className={styles.wrapper}>
-          <Switch>
-            <Route path='/pages/about' component={ (props) => <Page {...props} query='pages?slug=about' /> } />
-            <Route path='/pages/portfolio' component={ (props) => <Page {...props} query='pages?slug=portfolio' /> } />
-            <Route path='/pages/stack' component={ (props) => <Page {...props} query='pages?slug=stack' /> } />
-            <Route path='/pages' component={List} />
-
-            <Redirect to='/pages' />
-          </Switch>
-        </div>
-    )
-  }
+  return(
+      <div className={styles.wrapper}>
+        <Switch>
+          <Route path='/pages/:page' component={Page} />
+          <Route path='/pages' component={List} />
+          <Redirect to='/pages' />
+        </Switch>
+      </div>
+  )
 }

--- a/src/app/main/pages/list/List.jsx
+++ b/src/app/main/pages/list/List.jsx
@@ -16,7 +16,7 @@ export default class List extends Component {
   }
 
   componentDidMount() {
-    GET(API_V1 + 'pages?fields=id,header,caption,slug&sort=sequence', (payload) => {
+    GET(API_V1 + 'pages?mode=published&fields=id,header,caption,slug&sort=sequence', (payload) => {
       if (payload.hasErrors()) {
         Logger.error("Failed to load pages. Cause: " + payload.getErrors());
       } else {

--- a/src/app/main/pages/list/element/Element.jsx
+++ b/src/app/main/pages/list/element/Element.jsx
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { Redirect } from "react-router-dom";
+
 import ArrowBtn from 'modules/buttons/ArrowBtn.jsx';
 import Transition from 'modules/transition/Transition.jsx';
 
@@ -8,8 +10,10 @@ class Page extends Component {
   header = this.props.element.header
   caption = this.props.element.caption
   slug = this.props.element.slug
+  id = this.props.element.id
 
   state = {
+    redirect: false,
     triggerOut: false
   }
 
@@ -20,10 +24,19 @@ class Page extends Component {
   }
 
   redirect() {
-    this.props.history.push('/pages/' +  this.slug)
+    this.setState({
+      redirect: true
+    })
   }
 
   render() {
+    if (this.state.redirect) {
+      return <Redirect to={{
+          pathname: '/pages/' + this.slug,
+          state: {id: this.id}
+        }}/>
+    }
+
     let timing = 500 + (this.props.index * 200);
     return(
       <Transition

--- a/src/app/main/pages/page/Page.jsx
+++ b/src/app/main/pages/page/Page.jsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
 
 import Blocks from 'blocks/Blocks.jsx'
 import Transition from 'modules/transition/Transition.jsx'
@@ -16,11 +17,14 @@ const arrowTransitionConfig = {
 
 export default class Page extends Component {
   state = {
+    redirect: false,
     triggerOut: false
   }
 
-  onClick() {
-    this.props.history.push('/pages')
+  redirect() {
+    this.setState({
+      redirect: true
+    })
   }
 
   triggerOut() {
@@ -30,6 +34,10 @@ export default class Page extends Component {
   }
 
   render() {
+    if (this.state.redirect) {
+      return <Redirect to='/pages' />
+    }
+
     return(
       <div className={styles.wrapper}>
         <div className={styles.header}>
@@ -42,8 +50,8 @@ export default class Page extends Component {
         <div className={styles.blocks}>
           <Blocks
             triggerOut={this.state.triggerOut}
-            actionOut={this.onClick.bind(this)}
-            query={this.props.query}/>
+            actionOut={this.redirect.bind(this)}
+            query={'pages/' + this.props.location.state.id}/>
         </div>
       </div>
     )

--- a/src/constants/colors.scss
+++ b/src/constants/colors.scss
@@ -7,7 +7,10 @@ $main-background: hsla(40%, 5%, 7%, 1);
   @return rgba($color, $alpha);
 }
 
-// $brand: hsla(200, 39%, 54%, 1);
+@function mix-brand($color: $transparent, $weight: 50%) {
+  @return mix($brand, $color, $weight);
+}
+
 $brand: hsla(30, 39%, 54%, 1);
 
 $background: hsla(0, 0%, 100%, 1);


### PR DESCRIPTION
1. Adds calls to the new Action Endpoint to Publish, Unpublish, CheckOut, and CheckIn pages.
2. Pages are now dynamic routes. Slugs still make up the URI path name, but unless you navigate from the List you'll never find the page. Now I can add a page without updating code in client.
3. Converted all history.pushes to <Redirect /> components.
